### PR TITLE
feat: link leaderboard players to steam profiles

### DIFF
--- a/src/app/api/cache/combined-1v1/[limit]/route.ts
+++ b/src/app/api/cache/combined-1v1/[limit]/route.ts
@@ -5,7 +5,11 @@ export async function GET(_req: Request, ctx: { params: { limit?: string } }) {
     const rows = await fetchCombined1v1Max();
     const missing = rows.filter(r => !r.playerName).map(r => r.profileId);
     const map = missing.length ? await resolveNames(missing) : {};
-    for (const r of rows) r.playerName = r.playerName || map[r.profileId] || "Unknown";
+    for (const r of rows) {
+      const resolved = map[r.profileId];
+      if (!r.playerName) r.playerName = resolved?.name || "Unknown";
+      if (!r.steamId && resolved?.steamId) r.steamId = resolved.steamId;
+    }
 
     const limitParam = Number(ctx.params?.limit || '200');
     const limit = Number.isFinite(limitParam) && limitParam > 0 ? Math.floor(limitParam) : 200;

--- a/src/app/api/cache/combined-1v1/route.ts
+++ b/src/app/api/cache/combined-1v1/route.ts
@@ -7,7 +7,11 @@ export async function GET(request: Request) {
     const rows = await fetchCombined1v1Max();
     const missing = rows.filter(r => !r.playerName).map(r => r.profileId);
     const map = missing.length ? await resolveNames(missing) : {};
-    for (const r of rows) r.playerName = r.playerName || map[r.profileId] || "Unknown";
+    for (const r of rows) {
+      const resolved = map[r.profileId];
+      if (!r.playerName) r.playerName = resolved?.name || "Unknown";
+      if (!r.steamId && resolved?.steamId) r.steamId = resolved.steamId;
+    }
 
     const url = new URL(request.url);
     const limitParam = Number(url.searchParams.get('limit') || '200');

--- a/src/app/api/cache/leaderboard/[id]/[limit]/route.ts
+++ b/src/app/api/cache/leaderboard/[id]/[limit]/route.ts
@@ -13,7 +13,11 @@ export async function GET(_req: Request, ctx: { params: { id: string; limit: str
     const rows = await fetchLeaderboardRows(idNum, limit);
     const missing = rows.filter(r => !r.playerName).map(r => r.profileId);
     const map = missing.length ? await resolveNames(missing) : {};
-    for (const r of rows) r.playerName = r.playerName || map[r.profileId] || "Unknown";
+    for (const r of rows) {
+      const resolved = map[r.profileId];
+      if (!r.playerName) r.playerName = resolved?.name || "Unknown";
+      if (!r.steamId && resolved?.steamId) r.steamId = resolved.steamId;
+    }
 
     return Response.json({
       leaderboardId: idNum,

--- a/src/app/api/cache/leaderboard/[id]/route.ts
+++ b/src/app/api/cache/leaderboard/[id]/route.ts
@@ -9,7 +9,11 @@ export async function GET(_req: Request, ctx: { params: { id: string } }) {
     const rows = await fetchLeaderboardRows(idNum, 200);
     const missing = rows.filter(r => !r.playerName).map(r => r.profileId);
     const map = missing.length ? await resolveNames(missing) : {};
-    for (const r of rows) r.playerName = r.playerName || map[r.profileId] || "Unknown";
+    for (const r of rows) {
+      const resolved = map[r.profileId];
+      if (!r.playerName) r.playerName = resolved?.name || "Unknown";
+      if (!r.steamId && resolved?.steamId) r.steamId = resolved.steamId;
+    }
 
     return Response.json({
       leaderboardId: idNum,

--- a/src/app/api/combined/route.ts
+++ b/src/app/api/combined/route.ts
@@ -5,7 +5,11 @@ export async function GET() {
     const rows = await fetchCombined1v1();
     const missing = rows.filter(r => !r.playerName).map(r => r.profileId);
     const map = missing.length ? await resolveNames(missing) : {};
-    for (const r of rows) r.playerName = r.playerName || map[r.profileId] || "Unknown";
+    for (const r of rows) {
+      const resolved = map[r.profileId];
+      if (!r.playerName) r.playerName = resolved?.name || "Unknown";
+      if (!r.steamId && resolved?.steamId) r.steamId = resolved.steamId;
+    }
 
     return Response.json({
       leaderboardId: "combined-1v1",

--- a/src/app/api/ladder/route.ts
+++ b/src/app/api/ladder/route.ts
@@ -6,7 +6,11 @@ export async function GET(req: Request) {
     const rows = await fetchTop100(id);
     const missing = rows.filter(r => !r.playerName).map(r => r.profileId);
     const map = missing.length ? await resolveNames(missing) : {};
-    for (const r of rows) r.playerName = r.playerName || map[r.profileId] || "Unknown";
+    for (const r of rows) {
+      const resolved = map[r.profileId];
+      if (!r.playerName) r.playerName = resolved?.name || "Unknown";
+      if (!r.steamId && resolved?.steamId) r.steamId = resolved.steamId;
+    }
     return Response.json({
       leaderboardId: id,
       lastUpdated: new Date().toISOString(),

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -120,6 +120,42 @@ const FlagIcon = ({ countryCode, compact = false }: { countryCode: string; compa
   );
 };
 
+const SteamProfileLink = ({
+  steamId,
+  label,
+  size = "md",
+  className = "",
+}: {
+  steamId?: string;
+  label?: string;
+  size?: "sm" | "md";
+  className?: string;
+}) => {
+  if (!steamId) return null;
+  const dimension = size === "sm" ? "w-7 h-7" : "w-8 h-8";
+  const iconSize = size === "sm" ? "w-3.5 h-3.5" : "w-4 h-4";
+  const title = label ? `Open Steam profile for ${label}` : "Open Steam profile";
+  return (
+    <a
+      href={`https://steamcommunity.com/profiles/${steamId}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={title}
+      title={title}
+      className={`inline-flex items-center justify-center rounded-full border border-neutral-600/60 bg-neutral-800/70 text-neutral-300 transition-colors hover:text-white hover:border-neutral-400 hover:bg-neutral-700/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900 ${dimension} ${className}`}
+    >
+      <svg
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        aria-hidden="true"
+        className={`${iconSize}`}
+      >
+        <path d="M12 0a12 12 0 00-11.39 8.64l4.58 1.85a3.06 3.06 0 015.66-.86l3.02 1.23a3.91 3.91 0 113.72 4.89 3.9 3.9 0 01-3.81-3.24l-3.02-1.23a3.06 3.06 0 01-3.31 1.93l-4.13-1.67A12 12 0 1012 0zm4.27 9.6a1.95 1.95 0 101.95 1.95 1.95 1.95 0 00-1.95-1.95zm-7.65 5.09a1.62 1.62 0 101.62 1.62 1.62 1.62 0 00-1.62-1.62z" />
+      </svg>
+    </a>
+  );
+};
+
 // Format last match date
 const formatLastMatch = (dateInput?: Date | string): string => {
   if (!dateInput) return "Never";
@@ -1449,6 +1485,12 @@ export default function Home() {
                           >
                             {row.playerName}
                           </button>
+                          <SteamProfileLink
+                            steamId={row.steamId}
+                            label={row.playerName}
+                            size="sm"
+                            className="shrink-0"
+                          />
                         </div>
                       </td>
                       {isCombinedMode && (
@@ -1488,7 +1530,7 @@ export default function Home() {
                     </div>
 
                     {/* Player Name with Flag */}
-                    <div className={`flex items-center gap-1 min-w-0 flex-1 ${row.playerName === "Unknown" ? "text-neutral-500" : "text-white"}`}>
+                    <div className={`flex items-center gap-1.5 min-w-0 flex-1 ${row.playerName === "Unknown" ? "text-neutral-500" : "text-white"}`}>
                       {row.country && <FlagIcon countryCode={row.country} compact />}
                       <button
                         type="button"
@@ -1498,6 +1540,12 @@ export default function Home() {
                       >
                         {row.playerName}
                       </button>
+                      <SteamProfileLink
+                        steamId={row.steamId}
+                        label={row.playerName}
+                        size="sm"
+                        className="shrink-0"
+                      />
                       {isCombinedMode && (
                         <span className={`text-xs font-semibold ml-1 ${getFactionColor(row.faction || '')} inline-flex items-center gap-1`}>
                           <FactionLogo faction={row.faction || undefined} size={14} />
@@ -1602,6 +1650,11 @@ export default function Home() {
                         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-3">
                           <div className="flex items-center gap-2 sm:gap-3 flex-wrap">
                             <h4 className="text-white font-medium">{result.playerName}</h4>
+                            <SteamProfileLink
+                              steamId={result.steamId}
+                              label={result.playerName}
+                              className="shrink-0"
+                            />
                             {result.personalStats?.profile?.country && (
                               <div className="flex items-center gap-1">
                                 <FlagIcon countryCode={result.personalStats.profile.country} />


### PR DESCRIPTION
## Summary
- extend leaderboard data enrichment to capture Steam IDs alongside persona names
- surface Steam profile buttons in desktop and mobile leaderboards plus player search results
- create a reusable SteamProfileLink helper with accessible styling for the new icon buttons

## Testing
- npm run typecheck
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cde0d3c6dc832d92a3524c1c7559c6