### PR TITLE
Update replay upload to use parser game duration

### DIFF
--- a/src/types/dowde-replay-parser.d.ts
+++ b/src/types/dowde-replay-parser.d.ts
@@ -9,6 +9,12 @@ declare module 'dowde-replay-parser' {
     replayname?: string;
     mapname?: string;
     matchduration?: string;
+    /** Raw duration in seconds exposed by newer versions of the parser */
+    matchdurationseconds?: number;
+    matchDurationSeconds?: number;
+    /** Optional formatted duration label exposed by newer versions of the parser */
+    matchdurationlabel?: string;
+    matchDurationLabel?: string;
     profiles?: ReplayProfile[];
     [key: string]: any;
   }


### PR DESCRIPTION
## Summary
- extend the dowde replay parser typings to include the newly emitted duration fields
- update the replay upload metadata pipeline to consume the parser-provided seconds/label while keeping the legacy string fallback

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0aa73a590832dbbb91a23f45a5eba