### PR TITLE
fix: align replay share links with download endpoint

### DIFF
--- a/src/app/api/replays/download/route.ts
+++ b/src/app/api/replays/download/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { generateSignedReplayUrl, sanitizeReplayFilename, supabaseAdmin } from '../shared';
+
+const deriveFilenameFromPath = (path: string): string => {
+  const [, base] = path.split('__');
+  if (!base) {
+    return 'replay.rec';
+  }
+
+  const cleaned = base.replace(/[^a-zA-Z0-9\s\-_\.]/g, '').trim();
+  return cleaned || 'replay.rec';
+};
+
+export async function GET(req: NextRequest) {
+  if (!supabaseAdmin) {
+    return NextResponse.json({ error: 'supabase_not_configured' }, { status: 500 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const path = searchParams.get('path');
+
+  if (!path) {
+    return NextResponse.json({ error: 'missing_path' }, { status: 400 });
+  }
+
+  try {
+    const { url, downloadCount } = await generateSignedReplayUrl(req, path);
+
+    const fileResponse = await fetch(url);
+    if (!fileResponse.ok || !fileResponse.body) {
+      return NextResponse.json({ error: 'download_failed' }, { status: 502 });
+    }
+
+    let filename: string | null = null;
+
+    const { data: metaRow, error: metaError } = await supabaseAdmin
+      .from('replay_metadata')
+      .select('submitted_name, replay_name, original_name')
+      .eq('path', path)
+      .maybeSingle();
+
+    if (metaError) {
+      console.error('Failed to load replay metadata for download filename', metaError);
+    }
+
+    if (metaRow) {
+      filename = sanitizeReplayFilename(metaRow.submitted_name || metaRow.replay_name || metaRow.original_name);
+    }
+
+    if (!filename) {
+      filename = sanitizeReplayFilename(deriveFilenameFromPath(path));
+    }
+
+    const headers = new Headers(fileResponse.headers);
+    headers.set('Content-Type', fileResponse.headers.get('Content-Type') ?? 'application/octet-stream');
+    headers.set('Cache-Control', 'no-store');
+    headers.set('Content-Disposition', `attachment; filename="${filename}"`);
+    headers.set('X-Replay-Filename', filename);
+
+    if (typeof downloadCount === 'number' && Number.isFinite(downloadCount)) {
+      headers.set('X-Download-Count', String(downloadCount));
+    }
+
+    return new NextResponse(fileResponse.body, {
+      status: 200,
+      headers
+    });
+  } catch (error) {
+    const code = error instanceof Error ? error.message : 'download_failed';
+    console.error('Failed to serve replay download', error);
+    const status = code === 'supabase_not_configured' ? 500 : 500;
+    return NextResponse.json({ error: code || 'download_failed' }, { status });
+  }
+}

--- a/src/app/api/replays/shared.ts
+++ b/src/app/api/replays/shared.ts
@@ -1,0 +1,80 @@
+import { createClient } from '@supabase/supabase-js';
+import { createHash } from 'crypto';
+import type { NextRequest } from 'next/server';
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+export const REPLAYS_BUCKET = process.env.SUPABASE_REPLAYS_BUCKET ?? 'replays';
+const SIGNED_URL_TTL_SECONDS = 60 * 60; // 1 hour access window
+
+export const supabaseAdmin = SUPABASE_URL && SUPABASE_SERVICE_ROLE_KEY
+  ? createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, { auth: { persistSession: false } })
+  : null;
+
+export const getClientIpHash = (req: NextRequest): string => {
+  const forwarded = req.headers.get('x-forwarded-for');
+  const realIp = req.headers.get('x-real-ip');
+  const cfConnectingIp = req.headers.get('cf-connecting-ip');
+
+  const ip = cfConnectingIp || forwarded?.split(',')[0]?.trim() || realIp || 'unknown';
+
+  return createHash('sha256').update(ip).digest('hex');
+};
+
+export interface SignedReplayUrlResult {
+  url: string;
+  downloadCount: number | null;
+  alreadyDownloaded: boolean;
+}
+
+export async function generateSignedReplayUrl(req: NextRequest, path: string): Promise<SignedReplayUrlResult> {
+  if (!supabaseAdmin) {
+    throw new Error('supabase_not_configured');
+  }
+
+  const { data, error } = await supabaseAdmin
+    .storage
+    .from(REPLAYS_BUCKET)
+    .createSignedUrl(path, SIGNED_URL_TTL_SECONDS);
+
+  if (error || !data?.signedUrl) {
+    console.error('Failed to create signed URL for replay', error);
+    throw new Error('signed_url_failed');
+  }
+
+  let downloadCount: number | null = null;
+  let wasIncremented = false;
+
+  const ipHash = getClientIpHash(req);
+
+  const { data: incremented, error: incrementError } = await supabaseAdmin
+    .rpc('increment_replay_download', {
+      path_input: path,
+      ip_hash_input: ipHash
+    });
+
+  if (incrementError) {
+    console.error('Failed to increment replay download count', incrementError);
+  } else if (incremented && typeof incremented === 'object') {
+    downloadCount = Number(incremented.download_count ?? null);
+    wasIncremented = Boolean(incremented.incremented);
+  }
+
+  return {
+    url: data.signedUrl,
+    downloadCount,
+    alreadyDownloaded: !wasIncremented
+  };
+}
+
+export const sanitizeReplayFilename = (name: string | null | undefined): string => {
+  const cleaned = (name ?? '')
+    .replace(/\.rec$/i, '')
+    .replace(/[^a-zA-Z0-9\s\-_]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  const base = cleaned || 'replay';
+  return `${base}.rec`;
+};
+


### PR DESCRIPTION
## Summary
- extract Supabase download helpers into a shared module for replay routes
- add a dedicated /api/replays/download endpoint that streams files and surfaces filename/count metadata
- update the replays tab to download through the new endpoint and copy the same short URL when sharing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2a1e1fff4832db353a34de747cd52